### PR TITLE
Add unit test

### DIFF
--- a/features/theme-install.feature
+++ b/features/theme-install.feature
@@ -86,3 +86,14 @@ Feature: Install WordPress themes
       """
       Using cached file
       """
+  
+  Scenario: Activate theme with slug that does not match case sensitivity
+    Given a WP install
+
+    When I try `wp theme activate TwentySeventeen`
+    Then STDERR should contain:
+      """
+      Error: The 'TwentySeventeen' theme could not be found.
+      """
+    And STDOUT should be empty
+    And the return code should be 1

--- a/features/theme-install.feature
+++ b/features/theme-install.feature
@@ -86,14 +86,3 @@ Feature: Install WordPress themes
       """
       Using cached file
       """
-  
-  Scenario: Activate theme with slug that does not match case sensitivity
-    Given a WP install
-
-    When I try `wp theme activate TwentySeventeen`
-    Then STDERR should contain:
-      """
-      Error: The 'TwentySeventeen' theme could not be found.
-      """
-    And STDOUT should be empty
-    And the return code should be 1

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -517,3 +517,14 @@ Feature: Manage WordPress themes
       """
       Error: Can't find the requested theme's version 1.4.2 in the WordPress.org theme repository (HTTP code 404).
       """
+
+  Scenario: Theme activation fails when slug does not match exactly
+    Given a WP install
+
+    When I try `wp theme activate TwentySeventeen`
+    Then STDERR should contain:
+      """
+      Error: The 'TwentySeventeen' theme could not be found.
+      """
+    And STDOUT should be empty
+    And the return code should be 1


### PR DESCRIPTION
- Adds unit test to confirm case sensitivity is required when using theme slugs.

After trying to find a case that would reproduce the case sensitivity problem when using Theme slugs, @achyuthajoy and I determined this to be a good case to show that using a slug that did not match *exactly* would behave the same across all platforms.